### PR TITLE
Dockerベースイメージの刷新

### DIFF
--- a/centos7_ruby_mariadb/Dockerfile
+++ b/centos7_ruby_mariadb/Dockerfile
@@ -1,110 +1,32 @@
-FROM centos:centos7
+FROM ruby:3.0.7
 
-# The following is based on:
-# https://github.com/docker-library/ruby/blob/fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac/Dockerfile-slim.template
-
-RUN yum install -y \
-		bzip2 \
-		ca-certificates \
-		libffi-devel \
-		gdbm \
-		openssl-devel \
-		libreadline \
-		libyaml-devel \
-		procps-ng \
-		zlib-devel
-
-# skip installing gem documentation
-RUN mkdir -p /usr/local/etc \
-	&& { \
-		echo 'install: --no-document'; \
-		echo 'update: --no-document'; \
-	} >> /usr/local/etc/gemrc
-
-ENV RUBY_MAJOR 3.0
-ENV RUBY_VERSION 3.0.7
-ENV RUBY_DOWNLOAD_SHA256 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
-ENV RUBYGEMS_VERSION 3.2.32
-ENV BUNDLER_VERSION 2.2.32
-
-# some of ruby's build scripts are written in ruby
-#   we purge system ruby later to make sure our final image uses what we just built
-RUN set -ex \
-	\
-	&& buildDeps=' \
-		autoconf \
-		bison \
-		gcc \
-		bzip2-devel \
-		gdbm-devel \
-		glib2-devel \
-		ncurses-devel \
-		libreadline-devel \
-		libxml2-devel \
-		libxslt-devel \
-		make \
-	' \
-	&& yum install -y $buildDeps \
-	&& curl --output ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
-	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
-	\
-	&& mkdir -p /usr/src/ruby \
-	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
-	&& rm ruby.tar.xz \
-	\
-	&& cd /usr/src/ruby \
-	\
-# hack in "ENABLE_PATH_CHECK" disabling to suppress:
-#   warning: Insecure world writable dir
-	&& { \
-		echo '#define ENABLE_PATH_CHECK 0'; \
-		echo; \
-		cat file.c; \
-	} > file.c.new \
-	&& mv file.c.new file.c \
-	\
-	&& autoconf \
-	&& gnuArch="$(uname -m)-linux-gnu" \
-	&& ./configure \
-		--build="$gnuArch" \
-		--disable-install-doc \
-		--enable-shared \
-	&& make -j "$(nproc)" \
-	&& make install \
-	\
-	&& yum erase -y $buildDeps \
-	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION" \
-	&& gem install bundler --version "$BUNDLER_VERSION" --force
-
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_SILENCE_ROOT_WARNING=1 \
-	BUNDLE_APP_CONFIG="$GEM_HOME"
-# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
-ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
-# adjust permissions of a few directories for running "gem install" as an arbitrary user
-RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
-# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
-
+RUN apt-get update
+RUN apt-get install -y locales
 RUN localedef -f UTF-8 -i ja_JP /usr/lib/locale/ja_JP.UTF-8
 ENV LC_ALL=ja_JP.UTF-8
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
-# デフォルトで入っていないパッケージ
-RUN yum install -y which sudo epel-release
-RUN yum groupinstall -y 'Development Tools'
-# mysql、mysqldump コマンドを使用するため、mariadb-server パッケージをインストール
-RUN yum install -y mariadb-devel mariadb-server sudo
-# JavaScriptの実行用のv8-develをインストール
-RUN yum install -y v8-devel
+RUN apt-get update && apt-get install -y \
+		bzip2 \
+		ca-certificates \
+		libffi-dev \
+		libgdbm-dev \
+		libssl-dev \
+		libreadline-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev
+
+## デフォルトで入っていないパッケージ
+RUN apt-get update && apt-get install -y sudo software-properties-common
+RUN apt-get install -y build-essential
+## mysql、mysqldump コマンドを使用するため、mariadb-server パッケージをインストール
+RUN apt-get install -y libmariadb-dev mariadb-server sudo 
+# JavaScriptの実行用のパッケージをインストール
+RUN apt-get install -y libv8-dev nodejs
 
 # Git
-RUN yum install -y curl-devel expat-devel wget
+RUN apt-get update && apt-get install -y libcurl4-gnutls-dev libexpat1-dev wget gettext
 RUN wget https://github.com/git/git/archive/refs/tags/v2.28.1.tar.gz \
   && tar xvzf v2.28.1.tar.gz \
   && cd git-2.28.1 \

--- a/centos7_ruby_mariadb_nodejs/Dockerfile
+++ b/centos7_ruby_mariadb_nodejs/Dockerfile
@@ -1,134 +1,59 @@
-FROM centos:centos7
+FROM ruby:3.0.7-buster
 
-# The following is based on:
-# https://github.com/docker-library/ruby/blob/fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac/Dockerfile-slim.template
-
-RUN yum install -y \
-		bzip2 \
-		ca-certificates \
-		libffi-devel \
-		gdbm \
-		openssl-devel \
-		libreadline \
-		libyaml-devel \
-		procps-ng \
-		zlib-devel
-
-# skip installing gem documentation
-RUN mkdir -p /usr/local/etc \
-	&& { \
-		echo 'install: --no-document'; \
-		echo 'update: --no-document'; \
-	} >> /usr/local/etc/gemrc
-
-ENV RUBY_MAJOR 3.0
-ENV RUBY_VERSION 3.0.7
-ENV RUBY_DOWNLOAD_SHA256 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
-ENV RUBYGEMS_VERSION 3.2.32
-ENV BUNDLER_VERSION 2.2.32
-
-# some of ruby's build scripts are written in ruby
-#   we purge system ruby later to make sure our final image uses what we just built
-RUN set -ex \
-	\
-	&& buildDeps=' \
-		autoconf \
-		bison \
-		gcc \
-		bzip2-devel \
-		gdbm-devel \
-		glib2-devel \
-		ncurses-devel \
-		libreadline-devel \
-		libxml2-devel \
-		libxslt-devel \
-		make \
-	' \
-	&& yum install -y $buildDeps \
-	&& curl --output ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
-	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
-	\
-	&& mkdir -p /usr/src/ruby \
-	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
-	&& rm ruby.tar.xz \
-	\
-	&& cd /usr/src/ruby \
-	\
-# hack in "ENABLE_PATH_CHECK" disabling to suppress:
-#   warning: Insecure world writable dir
-	&& { \
-		echo '#define ENABLE_PATH_CHECK 0'; \
-		echo; \
-		cat file.c; \
-	} > file.c.new \
-	&& mv file.c.new file.c \
-	\
-	&& autoconf \
-	&& gnuArch="$(uname -m)-linux-gnu" \
-	&& ./configure \
-		--build="$gnuArch" \
-		--disable-install-doc \
-		--enable-shared \
-	&& make -j "$(nproc)" \
-	&& make install \
-	\
-	&& yum erase -y $buildDeps \
-	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION" \
-	&& gem install bundler --version "$BUNDLER_VERSION" --force
-
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_SILENCE_ROOT_WARNING=1 \
-	BUNDLE_APP_CONFIG="$GEM_HOME"
-# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
-ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
-# adjust permissions of a few directories for running "gem install" as an arbitrary user
-RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
-# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
-
+RUN apt-get update
+RUN apt-get install -y locales
 RUN localedef -f UTF-8 -i ja_JP /usr/lib/locale/ja_JP.UTF-8
 ENV LC_ALL=ja_JP.UTF-8
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
-# デフォルトで入っていないパッケージ
-RUN yum install -y which sudo epel-release
-RUN yum groupinstall -y 'Development Tools'
-# mysql、mysqldump コマンドを使用するため、mariadb-server パッケージをインストール
-RUN yum install -y mariadb-devel mariadb-server sudo
-# browser-test 実行に必要なパッケージ
-RUN yum install -y https://rpm.nodesource.com/pub_11.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
-RUN yum install -y nodejs alsa-lib gtk3 nss libXScrnSaver at-spi2-atk liberation-mono-fonts liberation-narrow-fonts liberation-sans-fonts  liberation-serif-font poppler-utils
-# xmlsectool 実行に必要なパッケージ
-RUN yum install -y  java-1.8.0-openjdk
-RUN echo "export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which java)))))" > /etc/profile.d/java.sh
-RUN echo 'export PATH=$PATH:$JAVA_HOME/bin' >> /etc/profile.d/java.sh
-# browser-testが文字化けしないようにするために必要なパッケージ
-# 参考: https://www.yurikago-blog.com/posts/2
-RUN yum install -y pango.x86_64 \
-    libXcomposite.x86_64 \
-    libXcursor.x86_64 \
-    libXdamage.x86_64 \
-    libXext.x86_64 \
-    libXi.x86_64 \
-    libXtst.x86_64 \
-    cups-libs.x86_64 \
-    libXScrnSaver.x86_64 \
-    libXrandr.x86_64 \
-    GConf2.x86_64 \
-    alsa-lib.x86_64 \
-    atk.x86_64 \
-    gtk3.x86_64 \
-    ipa-gothic-fonts \
-    xorg-x11-fonts-100dpi \
-    xorg-x11-fonts-75dpi \
-    xorg-x11-utils \
-    xorg-x11-fonts-cyrillic \
-    xorg-x11-fonts-Type1 \
-    xorg-x11-fonts-misc
+RUN apt-get update && apt-get install -y \
+		bzip2 \
+		ca-certificates \
+		libffi-dev \
+		libgdbm-dev \
+		libssl-dev \
+		libreadline-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev
 
+## デフォルトで入っていないパッケージ
+RUN apt-get update && apt-get install -y sudo software-properties-common
+RUN apt-get install -y build-essential
+## mysql、mysqldump コマンドを使用するため、mariadb-server パッケージをインストール
+RUN apt-get install -y libmariadb-dev mariadb-server sudo
+## browser-test 実行に必要なパッケージ
+RUN curl -SL https://deb.nodesource.com/setup_11.x | bash -
+RUN apt-get install -y nodejs libasound2 libgtk-3-0 libnss3 libxss1 libatk-bridge2.0-0 fonts-liberation libpoppler-glib8
+## xmlsectool 実行に必要なパッケージ
+RUN echo "path-exclude /usr/lib/jvm/java-11-openjdk-amd64/man/*" > /etc/dpkg/dpkg.cfg.d/openjdk-11 && \
+    apt update && \
+    apt -y install --no-install-recommends openjdk-11-jre-headless
+RUN echo "export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which java)))))" >> ~/.bashrc
+RUN echo 'export PATH=$PATH:$JAVA_HOME/bin' >> ~/.bashrc
+# 証明書が参照できずエラーとなる場合があるためシンボリックリンクを追加
+RUN ln -s /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
+## browser-testが文字化けしないようにするために必要なパッケージ
+## 参考: https://www.yurikago-blog.com/posts/2
+RUN apt-get install -y libpango1.0-0 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxi6 \
+    libxtst6 \
+    libcups2 \
+    libxss1 \
+    libxrandr2 \
+    libgconf-2-4 \
+    libasound2 \
+    libatk1.0-0 \
+    libgtk-3-0 \
+    fonts-ipafont-gothic \
+    xfonts-100dpi \
+    xfonts-75dpi \
+    x11-utils \
+    xfonts-cyrillic \
+    xfonts-base \
+    libgbm1
 CMD [ "irb" ]

--- a/centos7_ruby_mariadb_phantomjs/Dockerfile
+++ b/centos7_ruby_mariadb_phantomjs/Dockerfile
@@ -1,141 +1,59 @@
-FROM centos:centos7
+FROM ruby:3.2.2-buster
 
-# The following is based on:
-# https://github.com/docker-library/ruby/blob/fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac/Dockerfile-slim.template
-
-RUN yum install -y \
-		bzip2 \
-		ca-certificates \
-		libffi-devel \
-		gdbm \
-		openssl-devel \
-		libreadline \
-		libyaml-devel \
-		procps-ng \
-		zlib-devel
-
-# skip installing gem documentation
-RUN mkdir -p /usr/local/etc \
-	&& { \
-		echo 'install: --no-document'; \
-		echo 'update: --no-document'; \
-	} >> /usr/local/etc/gemrc
-
-ENV RUBY_MAJOR 3.2
-ENV RUBY_VERSION 3.2.4
-ENV RUBY_DOWNLOAD_SHA256 e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
-ENV RUBYGEMS_VERSION 3.3.3
-ENV BUNDLER_VERSION 1.17.3
-
-# some of ruby's build scripts are written in ruby
-#   we purge system ruby later to make sure our final image uses what we just built
-RUN set -ex \
-	\
-	&& buildDeps=' \
-		autoconf \
-		bison \
-		gcc \
-		bzip2-devel \
-		gdbm-devel \
-		glib2-devel \
-		ncurses-devel \
-		libreadline-devel \
-		readline-devel \
-		libxml2-devel \
-		libxslt-devel \
-		make \
-	' \
-	&& yum install -y $buildDeps \
-	&& curl --output ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
-	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
-	\
-	&& mkdir -p /usr/src/ruby \
-	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
-	&& rm ruby.tar.xz \
-	\
-	&& cd /usr/src/ruby \
-	\
-# hack in "ENABLE_PATH_CHECK" disabling to suppress:
-#   warning: Insecure world writable dir
-	&& { \
-		echo '#define ENABLE_PATH_CHECK 0'; \
-		echo; \
-		cat file.c; \
-	} > file.c.new \
-	&& mv file.c.new file.c \
-	\
-	&& autoconf \
-	&& gnuArch="$(uname -m)-linux-gnu" \
-	&& ./configure \
-		--build="$gnuArch" \
-		--disable-install-doc \
-		--enable-shared \
-	&& make -j "$(nproc)" \
-	&& make install \
-	\
-	&& yum erase -y $buildDeps \
-	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION" \
-	&& gem install bundler --version "$BUNDLER_VERSION" --force
-
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_SILENCE_ROOT_WARNING=1 \
-	BUNDLE_APP_CONFIG="$GEM_HOME"
-# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
-ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
-# adjust permissions of a few directories for running "gem install" as an arbitrary user
-RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
-# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
-
+RUN apt-get update
+RUN apt-get install -y locales
 RUN localedef -f UTF-8 -i ja_JP /usr/lib/locale/ja_JP.UTF-8
 ENV LC_ALL=ja_JP.UTF-8
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
-# デフォルトで入っていないパッケージ
-RUN yum install -y which sudo epel-release
-RUN yum groupinstall -y 'Development Tools'
-# mysql、mysqldump コマンドを使用するため、mariadb-server パッケージをインストール
-RUN yum install -y mariadb-devel mariadb-server sudo
-RUN yum install -y https://rpm.nodesource.com/pub_11.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm
-RUN yum install -y nodejs
-# browser-testが文字化けしないようにするために必要なパッケージ
-# 参考: https://www.yurikago-blog.com/posts/2
-RUN yum install -y pango.x86_64 \
-    libXcomposite.x86_64 \
-    libXcursor.x86_64 \
-    libXdamage.x86_64 \
-    libXext.x86_64 \
-    libXi.x86_64 \
-    libXtst.x86_64 \
-    cups-libs.x86_64 \
-    libXScrnSaver.x86_64 \
-    libXrandr.x86_64 \
-    GConf2.x86_64 \
-    alsa-lib.x86_64 \
-    atk.x86_64 \
-    gtk3.x86_64 \
-    ipa-gothic-fonts \
-    xorg-x11-fonts-100dpi \
-    xorg-x11-fonts-75dpi \
-    xorg-x11-utils \
-    xorg-x11-fonts-cyrillic \
-    xorg-x11-fonts-Type1 \
-    xorg-x11-fonts-misc
+RUN apt-get update && apt-get install -y \
+		bzip2 \
+		ca-certificates \
+		libffi-dev \
+		libgdbm-dev \
+		libssl-dev \
+		libreadline-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev
 
-# Git
-RUN yum install -y curl-devel expat-devel wget
-RUN wget https://github.com/git/git/archive/refs/tags/v2.28.1.tar.gz \
-  && tar xvzf v2.28.1.tar.gz \
-  && cd git-2.28.1 \
-  && make prefix=/usr/local all \
-  && make prefix=/usr/local install \
-  && cd / \
-  && rm v2.28.1.tar.gz \
-  && rm -r git-2.28.1
-
+## デフォルトで入っていないパッケージ
+RUN apt-get update && apt-get install -y sudo software-properties-common
+RUN apt-get install -y build-essential
+## mysql、mysqldump コマンドを使用するため、mariadb-server パッケージをインストール
+RUN apt-get install -y libmariadb-dev mariadb-server sudo
+## browser-test 実行に必要なパッケージ
+RUN curl -SL https://deb.nodesource.com/setup_11.x | bash -
+RUN apt-get install -y nodejs libasound2 libgtk-3-0 libnss3 libxss1 libatk-bridge2.0-0 fonts-liberation libpoppler-glib8
+## xmlsectool 実行に必要なパッケージ
+RUN echo "path-exclude /usr/lib/jvm/java-11-openjdk-amd64/man/*" > /etc/dpkg/dpkg.cfg.d/openjdk-11 && \
+    apt update && \
+    apt -y install --no-install-recommends openjdk-11-jre-headless
+RUN echo "export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which java)))))" >> ~/.bashrc
+RUN echo 'export PATH=$PATH:$JAVA_HOME/bin' >> ~/.bashrc
+# 証明書が参照できずエラーとなる場合があるためシンボリックリンクを追加
+RUN ln -s /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
+## browser-testが文字化けしないようにするために必要なパッケージ
+## 参考: https://www.yurikago-blog.com/posts/2
+RUN apt-get install -y libpango1.0-0 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxext6 \
+    libxi6 \
+    libxtst6 \
+    libcups2 \
+    libxss1 \
+    libxrandr2 \
+    libgconf-2-4 \
+    libasound2 \
+    libatk1.0-0 \
+    libgtk-3-0 \
+    fonts-ipafont-gothic \
+    xfonts-100dpi \
+    xfonts-75dpi \
+    x11-utils \
+    xfonts-cyrillic \
+    xfonts-base \
+    libgbm1
 CMD [ "irb" ]

--- a/centos7_ruby_openldap/Dockerfile
+++ b/centos7_ruby_openldap/Dockerfile
@@ -1,119 +1,41 @@
-FROM centos:centos7
+FROM ruby:3.0.7
 
-# The following is based on:
-# https://github.com/docker-library/ruby/blob/fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac/Dockerfile-slim.template
-
-RUN yum install -y \
-		bzip2 \
-		ca-certificates \
-		libffi-devel \
-		gdbm \
-		openssl-devel \
-		libreadline \
-		readline-devel \
-		libyaml-devel \
-		procps-ng \
-		zlib-devel
-
-# skip installing gem documentation
-RUN mkdir -p /usr/local/etc \
-	&& { \
-		echo 'install: --no-document'; \
-		echo 'update: --no-document'; \
-	} >> /usr/local/etc/gemrc
-
-ENV RUBY_MAJOR 3.0
-ENV RUBY_VERSION 3.0.5
-ENV RUBY_DOWNLOAD_SHA256 cf7cb5ba2030fe36596a40980cdecfd79a0337d35860876dc2b10a38675bddde
-ENV RUBYGEMS_VERSION 3.2.32
-ENV BUNDLER_VERSION 2.2.32
-
-# some of ruby's build scripts are written in ruby
-#   we purge system ruby later to make sure our final image uses what we just built
-RUN set -ex \
-	\
-	&& buildDeps=' \
-		autoconf \
-		bison \
-		gcc \
-		bzip2-devel \
-		gdbm-devel \
-		glib2-devel \
-		ncurses-devel \
-		libreadline-devel \
-		libxml2-devel \
-		libxslt-devel \
-		make \
-	' \
-	&& yum install -y $buildDeps \
-	&& curl --output ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
-	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
-	\
-	&& mkdir -p /usr/src/ruby \
-	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
-	&& rm ruby.tar.xz \
-	\
-	&& cd /usr/src/ruby \
-	\
-# hack in "ENABLE_PATH_CHECK" disabling to suppress:
-#   warning: Insecure world writable dir
-	&& { \
-		echo '#define ENABLE_PATH_CHECK 0'; \
-		echo; \
-		cat file.c; \
-	} > file.c.new \
-	&& mv file.c.new file.c \
-	\
-	&& autoconf \
-	&& gnuArch="$(uname -m)-linux-gnu" \
-	&& ./configure \
-		--build="$gnuArch" \
-		--disable-install-doc \
-		--enable-shared \
-	&& make -j "$(nproc)" \
-	&& make install \
-	\
-	&& yum erase -y $buildDeps \
-	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION" \
-	&& gem install bundler --version "$BUNDLER_VERSION" --force
-
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_SILENCE_ROOT_WARNING=1 \
-	BUNDLE_APP_CONFIG="$GEM_HOME"
-# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
-ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
-# adjust permissions of a few directories for running "gem install" as an arbitrary user
-RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
-# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
-
+RUN apt-get update
+RUN apt-get install -y locales
 RUN localedef -f UTF-8 -i ja_JP /usr/lib/locale/ja_JP.UTF-8
 ENV LC_ALL=ja_JP.UTF-8
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
-# デフォルトで入っていないパッケージ
-RUN yum install -y which sudo epel-release
-RUN yum groupinstall -y 'Development Tools'
-# mysql、mysqldump コマンドを使用するため、mariadb-server パッケージをインストール
-RUN yum install -y mariadb-devel mariadb-server sudo
-# JavaScriptの実行用のv8-develをインストール
-RUN yum install -y v8-devel
+RUN apt-get update && apt-get install -y \
+		bzip2 \
+		ca-certificates \
+		libffi-dev \
+		libgdbm-dev \
+		libssl-dev \
+		libreadline-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev
+
+## デフォルトで入っていないパッケージ
+RUN apt-get update && apt-get install -y sudo software-properties-common
+RUN apt-get install -y build-essential
+## mysql、mysqldump コマンドを使用するため、mariadb-server パッケージをインストール
+RUN apt-get install -y libmariadb-dev mariadb-server sudo
+# JavaScriptの実行用のパッケージをインストール
+RUN apt-get install -y libv8-dev nodejs
 # ruby-ldap のビルドに必要なパッケージ
-RUN yum install -y openldap-devel
+# ruby-ldap のビルドに必要なパッケージ
+RUN apt-get update && apt-get install -y libldap2-dev
 # Apache に必要なパッケージ
-RUN yum -y install httpd httpd-devel curl-devel
-RUN systemctl enable httpd
+RUN apt-get install -y apache2 apache2-dev libcurl4-openssl-dev
+RUN systemctl enable apache2
 RUN gem install passenger
 RUN passenger-install-apache2-module --auto --languages ruby
-RUN passenger-install-apache2-module --snippet > /etc/httpd/conf.modules.d/00-passenger.conf
+RUN passenger-install-apache2-module --snippet > /etc/apache2/mods-available/passenger.conf
 
 # Git
-RUN yum install -y curl-devel expat-devel wget
+RUN apt-get update && apt-get install -y libcurl4-gnutls-dev libexpat1-dev wget gettext
 RUN wget https://github.com/git/git/archive/refs/tags/v2.28.1.tar.gz \
   && tar xvzf v2.28.1.tar.gz \
   && cd git-2.28.1 \

--- a/centos7_ruby_sqlite3/Dockerfile
+++ b/centos7_ruby_sqlite3/Dockerfile
@@ -1,108 +1,32 @@
-FROM centos:centos7
+FROM ruby:3.0.7
 
-# The following is based on:
-# https://github.com/docker-library/ruby/blob/fc6fd1e86d41ca7efa2737374ca12f73c3bc42ac/Dockerfile-slim.template
-RUN yum install -y \
-		bzip2 \
-		ca-certificates \
-		libffi-devel \
-		gdbm \
-		openssl-devel \
-		libreadline \
-		libyaml-devel \
-		procps-ng \
-		zlib-devel
-
-# skip installing gem documentation
-RUN mkdir -p /usr/local/etc \
-	&& { \
-		echo 'install: --no-document'; \
-		echo 'update: --no-document'; \
-	} >> /usr/local/etc/gemrc
-
-ENV RUBY_MAJOR 3.0
-ENV RUBY_VERSION 3.0.7
-ENV RUBY_DOWNLOAD_SHA256 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
-ENV RUBYGEMS_VERSION 3.3.6
-ENV BUNDLER_VERSION 2.3.6
-
-# some of ruby's build scripts are written in ruby
-#   we purge system ruby later to make sure our final image uses what we just built
-RUN set -ex \
-	\
-	&& buildDeps=' \
-		autoconf \
-		bison \
-		gcc \
-		bzip2-devel \
-		gdbm-devel \
-		glib2-devel \
-		ncurses-devel \
-		libreadline-devel \
-		libxml2-devel \
-		libxslt-devel \
-		make \
-	' \
-	&& yum install -y $buildDeps \
-	&& curl --output ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
-	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
-	\
-	&& mkdir -p /usr/src/ruby \
-	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
-	&& rm ruby.tar.xz \
-	\
-	&& cd /usr/src/ruby \
-	\
-# hack in "ENABLE_PATH_CHECK" disabling to suppress:
-#   warning: Insecure world writable dir
-	&& { \
-		echo '#define ENABLE_PATH_CHECK 0'; \
-		echo; \
-		cat file.c; \
-	} > file.c.new \
-	&& mv file.c.new file.c \
-	\
-	&& autoconf \
-	&& gnuArch="$(uname -m)-linux-gnu" \
-	&& ./configure \
-		--build="$gnuArch" \
-		--disable-install-doc \
-		--enable-shared \
-	&& make -j "$(nproc)" \
-	&& make install \
-	\
-	&& yum erase -y $buildDeps \
-	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION" \
-	&& gem install bundler --version "$BUNDLER_VERSION" --force
-
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_SILENCE_ROOT_WARNING=1 \
-	BUNDLE_APP_CONFIG="$GEM_HOME"
-# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
-ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
-# adjust permissions of a few directories for running "gem install" as an arbitrary user
-RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
-# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
-
+RUN apt-get update
+RUN apt-get install -y locales
 RUN localedef -f UTF-8 -i ja_JP /usr/lib/locale/ja_JP.UTF-8
 ENV LC_ALL=ja_JP.UTF-8
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
-# デフォルトで入っていないパッケージ
-RUN yum install -y which sudo epel-release
-RUN yum groupinstall -y 'Development Tools'
+RUN apt-get update && apt-get install -y \
+		bzip2 \
+		ca-certificates \
+		libffi-dev \
+		libgdbm-dev \
+		libssl-dev \
+		libreadline-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev
 
-# sqlite3.gem のビルド時に必要なパッケージ
-RUN yum install -y sqlite-devel
+## デフォルトで入っていないパッケージ
+RUN apt-get update && apt-get install -y sudo software-properties-common
+RUN apt-get install -y build-essential
+## sqlite3.gem のビルド時に必要なパッケージ
+RUN apt-get install -y libsqlite3-dev
+# JavaScriptの実行用のパッケージをインストール
+RUN apt-get install -y libv8-dev nodejs
 
 # Git
-RUN yum install -y curl-devel expat-devel wget
+RUN apt-get update && apt-get install -y libcurl4-gnutls-dev libexpat1-dev wget gettext
 RUN wget https://github.com/git/git/archive/refs/tags/v2.28.1.tar.gz \
   && tar xvzf v2.28.1.tar.gz \
   && cd git-2.28.1 \
@@ -111,5 +35,3 @@ RUN wget https://github.com/git/git/archive/refs/tags/v2.28.1.tar.gz \
   && cd / \
   && rm v2.28.1.tar.gz \
   && rm -r git-2.28.1
-
-CMD [ "irb" ]


### PR DESCRIPTION
CentOS7のサポート終了に伴い、docker compose で使用するベースイメージを刷新しました