### PR TITLE
ブラウザテストのエラー解消のため、一部のベースイメージ・パッケージを更新

### DIFF
--- a/ruby_mariadb_nodejs/Dockerfile-ruby3.2.4
+++ b/ruby_mariadb_nodejs/Dockerfile-ruby3.2.4
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-buster
+FROM ruby:3.2.4
 
 RUN apt-get update
 RUN apt-get install -y locales
@@ -15,23 +15,24 @@ RUN apt-get update && apt-get install -y \
 		libreadline-dev \
 		libyaml-dev \
 		procps \
-		zlib1g-dev
+		zlib1g-dev \
+		npm
 
 ## デフォルトで入っていないパッケージ
 RUN apt-get update && apt-get install -y sudo software-properties-common build-essential
 ## mysql、mysqldump コマンドを使用するため、mariadb-server パッケージをインストール
 RUN apt-get install -y libmariadb-dev mariadb-server
 ## browser-test 実行に必要なパッケージ
-RUN curl -SL https://deb.nodesource.com/setup_11.x | bash -
+RUN curl -SL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get install -y nodejs libasound2 libgtk-3-0 libnss3 libxss1 libatk-bridge2.0-0 fonts-liberation poppler-utils
 ## xmlsectool 実行に必要なパッケージ
-RUN echo "path-exclude /usr/lib/jvm/java-11-openjdk-amd64/man/*" > /etc/dpkg/dpkg.cfg.d/openjdk-11 && \
+RUN echo "path-exclude /usr/lib/jvm/java-17-openjdk-amd64/man/*" > /etc/dpkg/dpkg.cfg.d/openjdk-17 && \
     apt update && \
-    apt -y install --no-install-recommends openjdk-11-jre-headless
+    apt -y install --no-install-recommends openjdk-17-jre-headless
 RUN echo "export JAVA_HOME=$(dirname $(dirname $(readlink $(readlink $(which java)))))" >> ~/.bashrc
 RUN echo 'export PATH=$PATH:$JAVA_HOME/bin' >> ~/.bashrc
-# 証明書が参照できずエラーとなる場合があるためシンボリックリンクを追加
-RUN ln -s /etc/ssl/certs/ca-certificates.crt /usr/lib/ssl/cert.pem
+## libffi.so.6が存在せずエラーとなるためシンボリックリンクを追加
+RUN sudo ln -s /usr/lib/x86_64-linux-gnu/libffi.so.8.1.2 /usr/lib/x86_64-linux-gnu/libffi.so.6
 ## browser-testが文字化けしないようにするために必要なパッケージ
 ## 参考: https://www.yurikago-blog.com/posts/2
 RUN apt-get install -y libpango1.0-0 \
@@ -52,7 +53,7 @@ RUN apt-get install -y libpango1.0-0 \
     xfonts-100dpi \
     xfonts-75dpi \
     x11-utils \
-    xfonts-cyrillic \
+    t1-cyrillic \
     xfonts-base \
     libgbm1
 CMD [ "irb" ]


### PR DESCRIPTION
https://github.com/NaCl-Ltd/nii-upki-sys/pull/129
上記で対応しているブラウザテストのエラーについて、使用イメージ(ruby_mariadb_nodejs)のベースイメージ・インストールパッケージを更新しました